### PR TITLE
Add a certificate info metric

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -275,6 +275,7 @@ func (n *NGINXController) Start() {
 			// manually update SSL expiration metrics
 			// (to not wait for a reload)
 			n.metricCollector.SetSSLExpireTime(n.runningConfig.Servers)
+			n.metricCollector.SetSSLInfo(n.runningConfig.Servers)
 		},
 		OnStoppedLeading: func() {
 			n.metricCollector.OnStoppedLeading(electionID)

--- a/internal/ingress/metric/collectors/controller_test.go
+++ b/internal/ingress/metric/collectors/controller_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package collectors
 
 import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
 	"testing"
 	"time"
 
@@ -96,9 +99,110 @@ func TestControllerCounters(t *testing.T) {
 			want: `
 				# HELP nginx_ingress_controller_ssl_expire_time_seconds Number of seconds since 1970 to the SSL Certificate expire.\n			An example to check if this certificate will expire in 10 days is: "nginx_ingress_controller_ssl_expire_time_seconds < (time() + (10 * 24 * 3600))"
 				# TYPE nginx_ingress_controller_ssl_expire_time_seconds gauge
-				nginx_ingress_controller_ssl_expire_time_seconds{class="nginx",host="demo",namespace="default"} 1.351807721e+09
+				nginx_ingress_controller_ssl_expire_time_seconds{class="nginx",host="demo",namespace="default",secret_name=""} 1.351807721e+09
 			`,
 			metrics: []string{"nginx_ingress_controller_ssl_expire_time_seconds"},
+		},
+		{
+			name: "should set SSL certificates infos metrics",
+			test: func(cm *Controller) {
+
+				servers := []*ingress.Server{
+					{
+						Hostname: "demo",
+						SSLCert: &ingress.SSLCert{
+							Name:      "secret-name",
+							Namespace: "ingress-namespace",
+							Certificate: &x509.Certificate{
+								PublicKeyAlgorithm: x509.ECDSA,
+								Issuer: pkix.Name{
+									CommonName:   "certificate issuer",
+									SerialNumber: "abcd1234",
+									Organization: []string{"issuer org"},
+								},
+								SerialNumber: big.NewInt(100),
+							},
+						},
+					},
+					{
+						Hostname: "invalid",
+						SSLCert: &ingress.SSLCert{
+							ExpireTime: time.Unix(0, 0),
+						},
+					},
+				}
+				cm.SetSSLInfo(servers)
+			},
+			want: `
+				# HELP nginx_ingress_controller_ssl_certificate_info Hold all labels associated to a certificate
+				# TYPE nginx_ingress_controller_ssl_certificate_info gauge
+				nginx_ingress_controller_ssl_certificate_info{class="nginx",host="demo",identifier="abcd1234-100",issuer_common_name="certificate issuer",issuer_organization="issuer org",namespace="ingress-namespace",public_key_algorithm="ECDSA",secret_name="secret-name",serial_number="100"} 1
+			`,
+			metrics: []string{"nginx_ingress_controller_ssl_certificate_info"},
+		},
+		{
+			name: "should ignore certificates without serial number",
+			test: func(cm *Controller) {
+
+				servers := []*ingress.Server{
+					{
+						Hostname: "demo",
+						SSLCert: &ingress.SSLCert{
+							Name:      "secret-name",
+							Namespace: "ingress-namespace",
+							Certificate: &x509.Certificate{
+								PublicKeyAlgorithm: x509.ECDSA,
+								Issuer: pkix.Name{
+									CommonName:   "certificate issuer",
+									SerialNumber: "abcd1234",
+								},
+							},
+						},
+					},
+				}
+				cm.SetSSLInfo(servers)
+			},
+			want:    ``,
+			metrics: []string{"nginx_ingress_controller_ssl_certificate_info"},
+		},
+		{
+			name: "should ignore certificates with nil x509 pointer",
+			test: func(cm *Controller) {
+
+				servers := []*ingress.Server{
+					{
+						Hostname: "demo",
+						SSLCert: &ingress.SSLCert{
+							Name:      "secret-name",
+							Namespace: "ingress-namespace",
+							Certificate: &x509.Certificate{
+								PublicKeyAlgorithm: x509.ECDSA,
+								Issuer: pkix.Name{
+									CommonName:   "certificate issuer",
+									SerialNumber: "abcd1234",
+								},
+							},
+						},
+					},
+				}
+				cm.SetSSLInfo(servers)
+			},
+			want:    ``,
+			metrics: []string{"nginx_ingress_controller_ssl_certificate_info"},
+		},
+		{
+			name: "should ignore servers without certificates",
+			test: func(cm *Controller) {
+
+				servers := []*ingress.Server{
+					{
+						Hostname: "demo",
+					},
+				}
+				cm.SetSSLInfo(servers)
+			},
+			want:    ``,
+			metrics: []string{"nginx_ingress_controller_ssl_certificate_info"},
 		},
 	}
 
@@ -137,6 +241,13 @@ func TestRemoveMetrics(t *testing.T) {
 			Hostname: "demo",
 			SSLCert: &ingress.SSLCert{
 				ExpireTime: t1,
+				Certificate: &x509.Certificate{
+					Issuer: pkix.Name{
+						CommonName:   "certificate issuer",
+						SerialNumber: "abcd1234",
+					},
+					SerialNumber: big.NewInt(100),
+				},
 			},
 		},
 		{
@@ -147,10 +258,61 @@ func TestRemoveMetrics(t *testing.T) {
 		},
 	}
 	cm.SetSSLExpireTime(servers)
+	cm.SetSSLInfo(servers)
 
-	cm.RemoveMetrics([]string{"demo"}, reg)
+	cm.RemoveMetrics([]string{"demo"}, []string{"abcd1234-100"}, reg)
 
 	if err := GatherAndCompare(cm, "", []string{"nginx_ingress_controller_ssl_expire_time_seconds"}, reg); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+	if err := GatherAndCompare(cm, "", []string{"nginx_ingress_controller_ssl_certificate_info"}, reg); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+
+	reg.Unregister(cm)
+}
+
+func TestRemoveAllSSLMetrics(t *testing.T) {
+	cm := NewController("pod", "default", "nginx")
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(cm); err != nil {
+		t.Errorf("registering collector failed: %s", err)
+	}
+
+	t1, _ := time.Parse(
+		time.RFC3339,
+		"2012-11-01T22:08:41+00:00")
+
+	servers := []*ingress.Server{
+		{
+			Hostname: "demo",
+			SSLCert: &ingress.SSLCert{
+				ExpireTime: t1,
+				Certificate: &x509.Certificate{
+					Issuer: pkix.Name{
+						CommonName:   "certificate issuer",
+						SerialNumber: "abcd1234",
+					},
+					SerialNumber: big.NewInt(100),
+				},
+			},
+		},
+		{
+			Hostname: "invalid",
+			SSLCert: &ingress.SSLCert{
+				ExpireTime: time.Unix(0, 0),
+			},
+		},
+	}
+	cm.SetSSLExpireTime(servers)
+	cm.SetSSLInfo(servers)
+
+	cm.RemoveAllSSLMetrics(reg)
+
+	if err := GatherAndCompare(cm, "", []string{"nginx_ingress_controller_ssl_expire_time_seconds"}, reg); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+	if err := GatherAndCompare(cm, "", []string{"nginx_ingress_controller_ssl_certificate_info"}, reg); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 

--- a/internal/ingress/metric/dummy.go
+++ b/internal/ingress/metric/dummy.go
@@ -48,13 +48,16 @@ func (dc DummyCollector) IncCheckCount(string, string) {}
 func (dc DummyCollector) IncCheckErrorCount(string, string) {}
 
 // RemoveMetrics ...
-func (dc DummyCollector) RemoveMetrics(ingresses, endpoints []string) {}
+func (dc DummyCollector) RemoveMetrics(ingresses, endpoints, certificates []string) {}
 
 // Start ...
 func (dc DummyCollector) Start(admissionStatus string) {}
 
 // Stop ...
 func (dc DummyCollector) Stop(admissionStatus string) {}
+
+// SetSSLInfo ...
+func (dc DummyCollector) SetSSLInfo([]*ingress.Server) {}
 
 // SetSSLExpireTime ...
 func (dc DummyCollector) SetSSLExpireTime([]*ingress.Server) {}

--- a/internal/ingress/sslcert.go
+++ b/internal/ingress/sslcert.go
@@ -18,6 +18,7 @@ package ingress
 
 import (
 	"crypto/x509"
+	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -67,6 +68,16 @@ type SSLCert struct {
 // GetObjectKind implements the ObjectKind interface as a noop
 func (s SSLCert) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
+}
+
+// Identifier returns a the couple issuer / serial number if they both exist, an empty string otherwise
+func (s SSLCert) Identifier() string {
+	if s.Certificate != nil {
+		if s.Certificate.SerialNumber != nil {
+			return fmt.Sprintf("%s-%s", s.Certificate.Issuer.SerialNumber, s.Certificate.SerialNumber.String())
+		}
+	}
+	return ""
 }
 
 // HashInclude defines if a field should be used or not to calculate the hash


### PR DESCRIPTION
When the ingress controller loads certificates  (new ones or following a
secret update), it performs a series of check to ensure its validity.

In our systems, we detected a case where, when the secret object is
compromised, for example when the certificate does not match the secret
key, different pods of the ingress controller are serving a different
version of the certificate.

This behaviour is due to the cache mechanism of the ingress controller,
keeping the last known certificate in case of corruption. When this
happens, old ingress-controller pods will keep serving the old one,
while new pods, by failing to load the corrupted certificates, would
use the default certificate, causing invalid certificates for its
clients.

This generates a random error on the client side, depending on the
actual pod instance it reaches.

In order to allow detecting occurences of those situations, add a metric
to expose, for all ingress controlller pods, detailed informations of
the currently loaded certificate.

This will, for example, allow setting an alert when there is a
certificate discrepency across all ingress controller pods using a query
similar to `sum(nginx_ingress_controller_ssl_certificate_info{host="name.tld"})by(serial_number)`

This also allows to catch other exceptions loading certificates (failing
to load the certificate from the k8s API, ...

Co-authored-by: Daniel Ricart <danielricart@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
